### PR TITLE
More shortcuts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toipe"
-description = "A trusty terminal typing tester for the tux."
+description = "A trusty terminal typing tester."
 repository = "https://github.com/Samyak2/toipe"
 readme = "README.md"
 categories = ["command-line-utilities"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If installed through `cargo`, use:
 toipe
 ```
 
+## Keyboard shortcuts
+
+See `toipe --help` for a list of keyboard shortcuts (the list can also be found [here](https://github.com/Samyak2/toipe/blob/main/src/config.rs#L10)).
+
 ## Show less or more text
 
 To change the number of words shown in each test, use the `-n` flag (default: 30):

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,17 @@
 
 use clap::Parser;
 
+const CLI_HELP: &str = "A trusty terminal typing tester.
+
+Keyboard shortcuts:
+ctrl-c: quit
+ctrl-r: restart test with a new set of words
+ctrc-w: delete last word
+";
+
 /// Main configuration for Toipe.
 #[derive(Parser)]
-#[clap(author, version, about)]
+#[clap(author, version, about = CLI_HELP)]
 pub struct ToipeConfig {
     /// Word list name or path to word list file.
     /// Available word lists:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,13 @@ impl<'a> Toipe {
 
         self.words = self.word_selector.new_words(self.config.num_words)?;
 
+        self.tui.display_lines_bottom(&[&[
+            Text::from("ctrl-r").with_color(color::Blue),
+            Text::from(" to restart, ").with_faint(),
+            Text::from("ctrl-c").with_color(color::Blue),
+            Text::from(" to quit ").with_faint(),
+        ]])?;
+
         self.show_words()?;
 
         Ok(())
@@ -272,15 +279,14 @@ impl<'a> Toipe {
                 Text::from(format!("{:.1} wpm", results.wpm())).with_color(color::Green),
                 Text::from(" (words per minute)"),
             ],
-            &[],
-            &[
-                Text::from("Press "),
-                Text::from("r").with_color(color::Blue),
-                Text::from(" to restart, "),
-                Text::from("q").with_color(color::Blue),
-                Text::from(" to quit."),
-            ],
         ])?;
+        self.tui.display_lines_bottom(&[&[
+            Text::from("Press "),
+            Text::from("r").with_color(color::Blue),
+            Text::from(" to restart, "),
+            Text::from("q").with_color(color::Blue),
+            Text::from(" to quit."),
+        ]])?;
         // no cursor on results page
         self.tui.hide_cursor()?;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -341,6 +341,32 @@ impl ToipeTui {
         Ok(())
     }
 
+    /// Displays multiple lines of text at the bottom of the screen.
+    ///
+    /// See [`display_lines`] for more information.
+    pub fn display_lines_bottom<T, U>(&mut self, lines: &[T]) -> MaybeError
+    where
+        T: AsRef<[U]>,
+        [U]: HasLength,
+        U: Display,
+    {
+        let (sizex, sizey) = terminal_size()?;
+
+        let line_offset = lines.len() as u16;
+
+        for (line_no, line) in lines.iter().enumerate() {
+            write!(
+                self.stdout,
+                "{}",
+                cursor::Goto(sizex / 2, sizey - 1 + (line_no as u16) - line_offset)
+            )?;
+            self.display_a_line_raw(line.as_ref())?;
+        }
+        self.flush()?;
+
+        Ok(())
+    }
+
     // TODO: document this
     pub fn display_words(&mut self, words: &[String]) -> MaybeError<Vec<Text>> {
         self.reset();


### PR DESCRIPTION
# Changes

Added keyboard shortcuts:
- `ctrl-r`: restart the typing test
- `ctrl-w`: delete the last word
- `ctrl-c`: exit directly (without going to results screen)

## Issues fixed

Fixes #15, fixes #16, fixes #18