### PR TITLE
Strip debuginfo in release profile to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ default-run = "toipe"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+strip = "debuginfo"
+
 [lib]
 
 [dependencies]


### PR DESCRIPTION
Closes #23 