### PR TITLE
Panic if can't find OS wordlist (Fixes #25)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,18 @@ impl<'a> Toipe {
             } else if let Some(word_list) = config.wordlist.contents() {
                 Box::new(RawWordSelector::from_string(word_list.to_string())?)
             } else if let BuiltInWordlist::OS = config.wordlist {
-                Box::new(RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH))?)
+                //Box::new(RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH))?)
+                let rws_result = RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH));
+                match rws_result {
+                    Ok(rws) => Box::new(rws),
+                    Err(e) => {
+                        // convert to toipe error
+                        let mut te = ToipeError::from(e);
+                        let msg_addition = "Error reading the given word list: ".to_string();
+                        te.msg = msg_addition + &te.msg;
+                        return Err(te);
+                    }
+                }
             } else {
                 // this should never happen!
                 // TODO: somehow enforce this at compile time?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,9 @@ pub struct ToipeError {
 }
 
 impl ToipeError {
-    /// Prefixes a ToipeError's msg with 'msg_context'
-    ///
-    /// The ToipeError operated on is consumed, and a new one is returned
-    pub fn with_context(mut self: Self, msg_context: &str) -> Self {
-        self.msg = msg_context.to_owned() + &self.msg;
+    /// Prefixes the message with a context
+    pub fn with_context(mut self: Self, context: &str) -> Self {
+        self.msg = context.to_owned() + &self.msg;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub struct ToipeError {
 
 impl ToipeError {
     /// Prefixes the message with a context
-    pub fn with_context(mut self: Self, context: &str) -> Self {
+    pub fn with_context(mut self, context: &str) -> Self {
         self.msg = context.to_owned() + &self.msg;
         self
     }


### PR DESCRIPTION
Improve error message context if we can't read a given word list. Add a `ToipeError` method, `with_context`, that prefixes the `msg` with a `str` you pass in. Use this method in each of the cases where `RawWordSelector` initialization can fail when initializing Toipe, so that errors from here say "Error reading the given word list: " at the front. (Fixes #25)