### PR TITLE
fix: print error message when terminal size is less the number of lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ impl std::fmt::Display for ToipeError {
     }
 }
 
-
 impl<'a> Toipe {
     /// Initializes a new typing test on the standard output.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@ impl From<std::io::Error> for ToipeError {
     }
 }
 
+impl std::fmt::Display for ToipeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.msg.as_str())
+    }
+}
+
+
 impl<'a> Toipe {
     /// Initializes a new typing test on the standard output.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub struct Toipe {
 }
 
 /// Represents any error caught in Toipe.
-#[derive(Debug)]
 pub struct ToipeError {
     pub msg: String,
 }
@@ -57,9 +56,15 @@ impl From<std::io::Error> for ToipeError {
     }
 }
 
-impl std::fmt::Display for ToipeError {
+impl From<String> for ToipeError {
+    fn from(error: String) -> Self {
+        ToipeError { msg: error }
+    }
+}
+
+impl std::fmt::Debug for ToipeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.msg.as_str())
+        f.write_str(format!("ToipeError: {}", self.msg).as_str())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,12 @@ use clap::StructOpt;
 use std::io::stdin;
 use toipe::config::ToipeConfig;
 use toipe::Toipe;
+use toipe::ToipeError;
 
-fn main() {
+fn main() -> Result<(), ToipeError> {
     let config = ToipeConfig::parse();
 
-    let res = Toipe::new(config);
-    if let Err(e) = res {
-        eprintln!("{}", e);
-        std::process::exit(1);
-    }
-
-    let mut toipe = res.unwrap();
+    let mut toipe = Toipe::new(config)?;
 
     let stdin = stdin();
 
@@ -24,4 +19,5 @@ fn main() {
             break;
         }
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,13 @@ use toipe::Toipe;
 fn main() {
     let config = ToipeConfig::parse();
 
-    let mut toipe = Toipe::new(config).unwrap();
+    let res = Toipe::new(config);
+    if let Err(e) = res {
+        eprintln!("{}", e.to_string());
+        std::process::exit(1);
+    }
+
+    let mut toipe = res.unwrap();
 
     let stdin = stdin();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), ToipeError> {
     loop {
         let stdin = stdin.lock();
         if let Ok((true, _)) = toipe.test(stdin) {
-            toipe.restart().unwrap();
+            toipe.restart()?;
         } else {
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let res = Toipe::new(config);
     if let Err(e) = res {
-        eprintln!("{}", e.to_string());
+        eprintln!("{}", e);
         std::process::exit(1);
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -397,8 +397,7 @@ impl ToipeTui {
                 lines.push(Text::from(line.join(" ") + " ").with_faint());
 
                 // clear line
-                line = Vec::new();
-                line.push(word.clone());
+                line = vec![word.clone()];
                 current_len = word.len() as u16 + 1;
             }
         }
@@ -409,17 +408,17 @@ impl ToipeTui {
         //   - won't hang there waiting for user to type space
         lines.push(Text::from(line.join(" ")).with_faint());
 
+        max_word_len = std::cmp::max(max_word_len + 1, 50);
         if lines.len() + self.bottom_lines_len + 2 > terminal_height as usize {
             return Err(ToipeError::from(format!(
                 "Terminal height is too short! Toipe requires at least {} lines, got {} lines",
                 lines.len() + self.bottom_lines_len + 2,
                 terminal_height,
             )));
-        } else if max_word_len + 1 > max_width as usize {
+        } else if max_word_len > max_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
-                max_word_len + 1,
-                max_width,
+                max_word_len, max_width,
             )));
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -409,15 +409,17 @@ impl ToipeTui {
         //   - won't hang there waiting for user to type space
         lines.push(Text::from(line.join(" ")).with_faint());
 
-        if lines.len() + self.bottom_lines_len + 1 >= terminal_height.into() {
+        if lines.len() + self.bottom_lines_len + 1 >= terminal_height as usize {
             return Err(ToipeError::from(format!(
-                "toipe requires atleast {} lines in your terminal",
-                lines.len() + self.bottom_lines_len + 1
+                "Terminal height is too short! Toipe requires at least {} lines, got {} lines",
+                lines.len() + self.bottom_lines_len + 1,
+                terminal_height,
             )));
-        } else if max_word_len >= max_width.into() {
+        } else if max_word_len >= max_width as usize {
             return Err(ToipeError::from(format!(
-                "toipe requires atleast {} columns in your terminal",
-                max_word_len
+                "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
+                max_word_len,
+                max_width,
             )));
         }
 
@@ -522,6 +524,8 @@ impl Drop for ToipeTui {
     /// Clears screen and sets the cursor to a non-blinking block.
     ///
     /// TODO: reset cursor to whatever it was before Toipe was started.
+    /// TODO: print error message when terminal height/width is too small.
+    /// Take a look at https://github.com/Samyak2/toipe/pull/28#discussion_r851784291 for more info.
     fn drop(&mut self) {
         write!(
             self.stdout,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -418,7 +418,8 @@ impl ToipeTui {
         } else if max_word_len + 1 > max_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
-                max_word_len + 1, max_width,
+                max_word_len + 1,
+                max_width,
             )));
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,6 +15,8 @@ use termion::{
 
 use crate::ToipeError;
 
+const MIN_LINE_WIDTH: usize = 50;
+
 /// Describes something that has a printable length.
 ///
 /// For example, a string containing color characters has a different
@@ -408,7 +410,7 @@ impl ToipeTui {
         //   - won't hang there waiting for user to type space
         lines.push(Text::from(line.join(" ")).with_faint());
 
-        max_word_len = std::cmp::max(max_word_len + 1, 50);
+        max_word_len = std::cmp::max(max_word_len + 1, MIN_LINE_WIDTH);
         if lines.len() + self.bottom_lines_len + 2 > terminal_height as usize {
             return Err(ToipeError::from(format!(
                 "Terminal height is too short! Toipe requires at least {} lines, got {} lines",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -399,7 +399,7 @@ impl ToipeTui {
                 // clear line
                 line = Vec::new();
                 line.push(word.clone());
-                current_len = 0;
+                current_len = word.len() as u16 + 1;
             }
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -412,7 +412,7 @@ impl ToipeTui {
         if lines.len() + self.bottom_lines_len + 1 >= terminal_height.into() {
             return Err(ToipeError::from(format!(
                 "toipe requires atleast {} lines in your terminal",
-                lines.len()
+                lines.len() + self.bottom_lines_len + 1
             )));
         } else if max_word_len >= max_width.into() {
             return Err(ToipeError::from(format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -418,8 +418,7 @@ impl ToipeTui {
         } else if max_word_len >= max_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
-                max_word_len,
-                max_width,
+                max_word_len, max_width,
             )));
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -409,16 +409,16 @@ impl ToipeTui {
         //   - won't hang there waiting for user to type space
         lines.push(Text::from(line.join(" ")).with_faint());
 
-        if lines.len() + self.bottom_lines_len + 1 >= terminal_height as usize {
+        if lines.len() + self.bottom_lines_len + 2 > terminal_height as usize {
             return Err(ToipeError::from(format!(
                 "Terminal height is too short! Toipe requires at least {} lines, got {} lines",
-                lines.len() + self.bottom_lines_len + 1,
+                lines.len() + self.bottom_lines_len + 2,
                 terminal_height,
             )));
-        } else if max_word_len >= max_width as usize {
+        } else if max_word_len + 1 > max_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
-                max_word_len, max_width,
+                max_word_len + 1, max_width,
             )));
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -405,7 +405,10 @@ impl ToipeTui {
 
         if lines.len() >= terminal_height.into() {
             return Err(ToipeError {
-                msg: format!("toipe requires atleast {} lines in your terminal", lines.len()),
+                msg: format!(
+                    "toipe requires atleast {} lines in your terminal",
+                    lines.len()
+                ),
             });
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -373,7 +373,7 @@ impl ToipeTui {
         let mut current_len = 0;
         let mut line = Vec::new();
         let mut lines = Vec::new();
-        let (terminal_width, _) = terminal_size()?;
+        let (terminal_width, terminal_height) = terminal_size()?;
         // 40% of terminal width
         let max_width = terminal_width * 2 / 5;
         const MAX_WORDS_PER_LINE: usize = 10;
@@ -402,6 +402,12 @@ impl ToipeTui {
         //   - the typing test stops as soon as the user types last char
         //   - won't hang there waiting for user to type space
         lines.push(Text::from(line.join(" ")).with_faint());
+
+        if lines.len() >= terminal_height.into() {
+            return Err(ToipeError {
+                msg: format!("toipe requires atleast {} lines in your terminal", lines.len()),
+            });
+        }
 
         self.track_lines = true;
         self.display_lines(


### PR DESCRIPTION
fixes #19 

this is my first time writing rust code, so please let me know if there is a better way of doing this.