### PR TITLE
fix: use terminal_width to check min width

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -417,10 +417,10 @@ impl ToipeTui {
                 lines.len() + self.bottom_lines_len + 2,
                 terminal_height,
             )));
-        } else if max_word_len > max_width as usize {
+        } else if max_word_len > terminal_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
-                max_word_len, max_width,
+                max_word_len, terminal_width,
             )));
         }
 


### PR DESCRIPTION
instead of max_width which is just 40% of the actual width (used to keep words on the screen in a comfortable manner)