### PR TITLE
Close some TODOs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,9 +24,8 @@ pub struct ToipeConfig {
     pub wordlist: BuiltInWordlist,
     /// Path to custom word list file.
     ///
-    /// Providing this will override `-w`/`--wordlist`.
-    // TODO: find a way to ensure `-w` isn't provided along with this.
-    #[clap(short = 'f', long = "file")]
+    /// This argument cannot be used along with `-w`/`--wordlist`
+    #[clap(short = 'f', long = "file", conflicts_with = "wordlist")]
     pub wordlist_file: Option<String>,
     /// Number of words to show on each test.
     #[clap(short, long, default_value_t = 30)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,9 +325,9 @@ impl<'a> Toipe {
         let mut to_restart: Option<bool> = None;
         while to_restart.is_none() {
             match keys.next().unwrap()? {
-                // press 'r' to restart
+                // press ctrl + 'r' to restart
                 Key::Ctrl('r') => to_restart = Some(true),
-                // press 'q' to quit
+                // press ctrl + 'c' to quit
                 Key::Ctrl('c') => to_restart = Some(false),
                 _ => {}
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -499,7 +499,7 @@ impl ToipeTui {
         Ok(())
     }
 
-    /// Moves the cursor to cur_pos
+    /// Moves the cursor to just before the character to be typed next
     pub fn move_to_cur_pos(&mut self) -> MaybeError {
         let (x, y) = self.cursor_pos.cur_pos();
         write!(self.stdout, "{}", cursor::Goto(x, y))?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -483,7 +483,7 @@ impl ToipeTui {
         Ok(())
     }
 
-    // TODO: document this
+    /// Moves the cursor to the next char
     pub fn move_to_next_char(&mut self) -> MaybeError {
         let (x, y) = self.cursor_pos.next();
         write!(self.stdout, "{}", cursor::Goto(x, y))?;
@@ -491,7 +491,7 @@ impl ToipeTui {
         Ok(())
     }
 
-    // TODO: document this
+    /// Moves the cursor to the previous char
     pub fn move_to_prev_char(&mut self) -> MaybeError {
         let (x, y) = self.cursor_pos.prev();
         write!(self.stdout, "{}", cursor::Goto(x, y))?;
@@ -499,7 +499,7 @@ impl ToipeTui {
         Ok(())
     }
 
-    // TODO: document this
+    /// Moves the cursor to cur_pos
     pub fn move_to_cur_pos(&mut self) -> MaybeError {
         let (x, y) = self.cursor_pos.cur_pos();
         write!(self.stdout, "{}", cursor::Goto(x, y))?;
@@ -507,7 +507,7 @@ impl ToipeTui {
         Ok(())
     }
 
-    // TODO: document this
+    /// Returns the current line the cursor is on
     pub fn current_line(&self) -> usize {
         self.cursor_pos.cur_line
     }
@@ -524,7 +524,6 @@ impl Drop for ToipeTui {
     ///
     /// Clears screen and sets the cursor to a non-blinking block.
     ///
-    /// TODO: reset cursor to whatever it was before Toipe was started.
     /// TODO: print error message when terminal height/width is too small.
     /// Take a look at https://github.com/Samyak2/toipe/pull/28#discussion_r851784291 for more info.
     fn drop(&mut self) {


### PR DESCRIPTION
This PR closes multiple TODOs.

The "reset cursor to whatever it was before Toipe was started." TODO is, from what I can tell, unfortunately impossible due to the limitations of escape sequences used to change the cursor shape, therefore removed. See <a href="https://github.com/neovim/neovim/issues/4867#issuecomment-223725876">this discussion</a> on the neovim repo.