### PR TITLE
Better errors using `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +383,7 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 name = "toipe"
 version = "0.4.1"
 dependencies = [
+ "anyhow",
  "bisection",
  "clap",
  "include-flate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,7 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 name = "toipe"
 version = "0.4.1"
 dependencies = [
+ "anyhow",
  "bisection",
  "clap",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ strip = "debuginfo"
 [lib]
 
 [dependencies]
-termion = "1.5.6"
-rand = "0.8.4"
+anyhow = "1.0"
 bisection = "0.1.0"
 clap = { version = "3.0.5", features = ["derive", "color", "suggestions"] }
+rand = "0.8.4"
+termion = "1.5.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl<'a> Toipe {
                 RawWordSelector::from_path(PathBuf::from(wordlist_path.clone())).with_context(
                     || {
                         format!(
-                            "Error reading the word list from given path '{}'",
+                            "reading the word list from given path '{}'",
                             wordlist_path
                         )
                     },
@@ -91,14 +91,14 @@ impl<'a> Toipe {
         } else if let Some(word_list) = config.wordlist.contents() {
             Box::new(
                 RawWordSelector::from_string(word_list.to_string()).with_context(|| {
-                    format!("Error reading the built-in word list {:?}", config.wordlist)
+                    format!("reading the built-in word list {:?}", config.wordlist)
                 })?,
             )
         } else if let BuiltInWordlist::OS = config.wordlist {
             Box::new(
                 RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH)).with_context(|| {
                     format!(
-                        "Error reading from the OS wordlist at path '{}'",
+                        "reading from the OS wordlist at path '{}'",
                         OS_WORDLIST_PATH
                     )
                 })?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl<'a> Toipe {
             Box::new(
                 RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH)).with_context(|| {
                     format!(
-                        "reading from the OS wordlist at path '{}'",
+                        "reading from the OS wordlist at path '{}'. See https://en.wikipedia.org/wiki/Words_(Unix) for more info on this file and how it can be installed.",
                         OS_WORDLIST_PATH
                     )
                 })?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,14 @@ pub struct ToipeError {
     pub msg: String,
 }
 
+impl ToipeError {
+    /// Prefixes the message with a context
+    pub fn with_context(mut self, context: &str) -> Self {
+        self.msg = context.to_owned() + &self.msg;
+        self
+    }
+}
+
 /// Converts [`std::io::Error`] to [`ToipeError`].
 ///
 /// This keeps only the error message.
@@ -76,20 +84,26 @@ impl<'a> Toipe {
     /// Initializes the word selector.
     /// Also invokes [`Toipe::restart()`].
     pub fn new(config: ToipeConfig) -> Result<Self, ToipeError> {
-        let word_selector: Box<dyn WordSelector> =
+        let word_selector: Result<Box<dyn WordSelector>, _> =
             if let Some(wordlist_path) = config.wordlist_file.clone() {
-                Box::new(RawWordSelector::from_path(PathBuf::from(wordlist_path))?)
+                RawWordSelector::from_path(PathBuf::from(wordlist_path))
+                    .map(|ws| Box::new(ws) as Box<dyn WordSelector>)
             } else if let Some(word_list) = config.wordlist.contents() {
-                Box::new(RawWordSelector::from_string(word_list.to_string())?)
+                RawWordSelector::from_string(word_list.to_string())
+                    .map(|ws| Box::new(ws) as Box<dyn WordSelector>)
             } else if let BuiltInWordlist::OS = config.wordlist {
-                Box::new(RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH))?)
+                RawWordSelector::from_path(PathBuf::from(OS_WORDLIST_PATH))
+                    .map(|ws| Box::new(ws) as Box<dyn WordSelector>)
             } else {
                 // this should never happen!
                 // TODO: somehow enforce this at compile time?
-                return Err(ToipeError {
-                    msg: "Undefined word list or path.".to_string(),
-                });
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Undefined word list or path.",
+                ))
             };
+        let word_selector = word_selector
+            .map_err(|e| ToipeError::from(e).with_context("Error reading the given word list: "))?;
 
         let mut toipe = Toipe {
             tui: ToipeTui::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub struct Toipe {
 /// Represents any error caught in Toipe.
 #[derive(Debug)]
 pub struct ToipeError {
+    /// Error message. Should not start with "error" or similar.
     pub msg: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,7 @@ impl<'a> Toipe {
         {
             Box::new(
                 RawWordSelector::from_path(PathBuf::from(wordlist_path.clone())).with_context(
-                    || {
-                        format!(
-                            "reading the word list from given path '{}'",
-                            wordlist_path
-                        )
-                    },
+                    || format!("reading the word list from given path '{}'", wordlist_path),
                 )?,
             )
         } else if let Some(word_list) = config.wordlist.contents() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
+use anyhow::Result;
 use clap::StructOpt;
+
 use std::io::stdin;
 use toipe::config::ToipeConfig;
 use toipe::Toipe;
-use toipe::ToipeError;
 
-fn main() -> Result<(), ToipeError> {
+fn main() -> Result<()> {
     let config = ToipeConfig::parse();
 
     let mut toipe = Toipe::new(config)?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -14,6 +14,7 @@ use termion::{
 };
 
 use crate::ToipeError;
+use anyhow::Result;
 
 const MIN_LINE_WIDTH: usize = 50;
 
@@ -228,7 +229,7 @@ pub struct ToipeTui {
     bottom_lines_len: usize,
 }
 
-type MaybeError<T = ()> = Result<T, ToipeError>;
+type MaybeError<T = ()> = Result<T>;
 
 impl ToipeTui {
     /// Initializes stdout in raw mode for the TUI.
@@ -416,12 +417,14 @@ impl ToipeTui {
                 "Terminal height is too short! Toipe requires at least {} lines, got {} lines",
                 lines.len() + self.bottom_lines_len + 2,
                 terminal_height,
-            )));
+            ))
+            .into());
         } else if max_word_len > terminal_width as usize {
             return Err(ToipeError::from(format!(
                 "Terminal width is too low! Toipe requires at least {} columns, got {} columns",
                 max_word_len, terminal_width,
-            )));
+            ))
+            .into());
         }
 
         self.track_lines = true;

--- a/src/wordlists.rs
+++ b/src/wordlists.rs
@@ -5,7 +5,7 @@ use clap::ArgEnum;
 /// Word lists with top English words.
 ///
 /// See [variants](#variants) for details on each word list.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, Debug)]
 pub enum BuiltInWordlist {
     /// Source: [wordfrequency.info](https://www.wordfrequency.info/samples.asp) (top 60K lemmas sample).
     Top250,


### PR DESCRIPTION
# Summary

- Use `anyhow::Result` instead of std/core's `Result`.
- Add context to word list errors to say what exactly failed. Fixes #25 
- This includes the commits from #26 to provide credit for moving this in the right direction. Thanks @benliepert!