### PR TITLE
Compress bundled wordlists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +115,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdcb449c721557c1cf89bbd3412bf33fa963289e26e9badbd824a960912e148"
+dependencies = [
+ "include-flate-codegen-exports",
+ "lazy_static",
+ "libflate",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
+dependencies = [
+ "libflate",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "include-flate-codegen-exports"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75657043ffe3d8280f1cb8aef0f505532b392ed7758e0baeac22edadcee31a03"
+dependencies = [
+ "include-flate-codegen",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +169,26 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "libflate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "memchr"
@@ -171,6 +240,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -249,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +379,7 @@ version = "0.4.1"
 dependencies = [
  "bisection",
  "clap",
+ "include-flate",
  "rand",
  "termion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ termion = "1.5.6"
 rand = "0.8.4"
 bisection = "0.1.0"
 clap = { version = "3.0.5", features = ["derive", "color", "suggestions"] }
+include-flate = {version ="0.1.4", features=["stable"]}

--- a/src/wordlists.rs
+++ b/src/wordlists.rs
@@ -58,13 +58,13 @@ impl BuiltInWordlist {
     /// Reading the file can take time (and memory) as the file can be large.
     pub fn contents(&self) -> Option<&'static str> {
         match self {
-            Self::Top250    => Some(&TOP_250),
-            Self::Top500    => Some(&TOP_500),
-            Self::Top1000   => Some(&TOP_1000),
-            Self::Top2500   => Some(&TOP_2500),
-            Self::Top5000   => Some(&TOP_5000),
-            Self::Top10000  => Some(&TOP_10000),
-            Self::Top25000  => Some(&TOP_25000),
+            Self::Top250 => Some(&TOP_250),
+            Self::Top500 => Some(&TOP_500),
+            Self::Top1000 => Some(&TOP_1000),
+            Self::Top2500 => Some(&TOP_2500),
+            Self::Top5000 => Some(&TOP_5000),
+            Self::Top10000 => Some(&TOP_10000),
+            Self::Top25000 => Some(&TOP_25000),
             Self::CommonlyMisspelled => Some(&TOP_MISSPELLED),
             Self::OS => None,
         }

--- a/src/wordlists.rs
+++ b/src/wordlists.rs
@@ -1,6 +1,4 @@
 //! Built-in wordlists, system wordlist and utils for retrieving them.
-// #![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
 use clap::ArgEnum;
 use include_flate::flate;
 

--- a/src/wordlists.rs
+++ b/src/wordlists.rs
@@ -1,6 +1,17 @@
 //! Built-in wordlists, system wordlist and utils for retrieving them.
+// #![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
 
 use clap::ArgEnum;
+use include_flate::flate;
+
+flate!(static TOP_250: str          from "src/word_lists/top250");
+flate!(static TOP_500: str          from "src/word_lists/top500");
+flate!(static TOP_1000: str         from "src/word_lists/top1000");
+flate!(static TOP_2500: str         from "src/word_lists/top2500");
+flate!(static TOP_5000: str         from "src/word_lists/top5000");
+flate!(static TOP_10000: str        from "src/word_lists/top10000");
+flate!(static TOP_25000: str        from "src/word_lists/top25000");
+flate!(static TOP_MISSPELLED: str   from "src/word_lists/commonly_misspelled");
 
 /// Word lists with top English words.
 ///
@@ -47,14 +58,14 @@ impl BuiltInWordlist {
     /// Reading the file can take time (and memory) as the file can be large.
     pub fn contents(&self) -> Option<&'static str> {
         match self {
-            Self::Top250 => Some(include_str!("word_lists/top250")),
-            Self::Top500 => Some(include_str!("word_lists/top500")),
-            Self::Top1000 => Some(include_str!("word_lists/top1000")),
-            Self::Top2500 => Some(include_str!("word_lists/top2500")),
-            Self::Top5000 => Some(include_str!("word_lists/top5000")),
-            Self::Top10000 => Some(include_str!("word_lists/top10000")),
-            Self::Top25000 => Some(include_str!("word_lists/top25000")),
-            Self::CommonlyMisspelled => Some(include_str!("word_lists/commonly_misspelled")),
+            Self::Top250    => Some(&TOP_250),
+            Self::Top500    => Some(&TOP_500),
+            Self::Top1000   => Some(&TOP_1000),
+            Self::Top2500   => Some(&TOP_2500),
+            Self::Top5000   => Some(&TOP_5000),
+            Self::Top10000  => Some(&TOP_10000),
+            Self::Top25000  => Some(&TOP_25000),
+            Self::CommonlyMisspelled => Some(&TOP_MISSPELLED),
             Self::OS => None,
         }
     }


### PR DESCRIPTION
Hey! I came across your project and figured I'd take a crack some of the issues listed.
This PR should solve issue: https://github.com/Samyak2/toipe/issues/31

To compress the bundled wordlist, I've used [include-flate](https://crates.io/crates/include-flate)'s ```flate!``` macro as a replacement for ```include_str!```.
This will compress the wordlists during compilation.

### Size comparison for "toipe"
I'm currently using Arch Linux with rust stable, so your results may vary.

* Total wordlist size: ```367.3KiB``` (380,167 Bytes)
* Binary size using ```include_str!```: ```1.4MiB``` (1,452,728 Bytes)
* Binary size using ```flate!```: ```1.2 MiB``` (1,268,408 Bytes)

I've tested both binaries and I couldn't find any performance hits (compilation & runtime).