### PR TITLE
Add Results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +139,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -217,6 +251,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
@@ -427,10 +467,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
@@ -514,6 +566,7 @@ dependencies = [
  "bisection",
  "chrono",
  "clap",
+ "csv",
  "include-flate",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,10 +47,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -72,6 +103,22 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crc32fast"
@@ -112,6 +159,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1779539f58004e5dba1c1f093d44325ebeb244bfc04b791acdc0aaeca9c04570"
+dependencies = [
+ "android_system_properties",
+ "core-foundation",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -159,6 +219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,9 +235,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
 name = "libflate"
@@ -191,16 +260,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -249,11 +352,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -330,6 +433,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "serde"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,13 +460,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -374,21 +497,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "toipe"
 version = "0.4.1"
 dependencies = [
  "bisection",
+ "chrono",
  "clap",
  "include-flate",
  "rand",
+ "serde",
  "termion",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"
@@ -398,9 +534,63 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ rand = "0.8.4"
 bisection = "0.1.0"
 clap = { version = "3.0.5", features = ["derive", "color", "suggestions"] }
 include-flate = {version ="0.1.4", features=["stable"]}
+serde = { version = "1.0.143", features = ["derive"] }
+chrono = { version = "0.4.21", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ strip = "debuginfo"
 termion = "1.5.6"
 rand = "0.8.4"
 bisection = "0.1.0"
+csv = "1.1.6"
 clap = { version = "3.0.5", features = ["derive", "color", "suggestions"] }
 include-flate = {version ="0.1.4", features=["stable"]}
 serde = { version = "1.0.143", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ You can provide your own word list too (Note: the word list must meet [these ass
 toipe -f /path/to/word/list
 ```
 
+## Save Results
+
+By default results are not saved. To enable result saves either pass the `-r` flag and a valid path or use the environment variable: `TOIPE_RESULTS_FILE` set to a given file path you'd like to save results to.
+
+For example:
+
+```
+toipe -r save_results.csv
+```
+
+Or, with an environment variable in a Bash shell:
+
+```bash
+export TOIPE_RESULTS_FILE="${HOME}/.toipe-results"
+toipe
+```
+
+Toipe outputs its saved results in `csv` format.
+
 # Platform support
 
 - toipe was only tested on Linux. If you find any problems, please [open an issue](https://github.com/Samyak2/toipe/issues).

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct ToipeConfig {
     /// Number of words to show on each test.
     #[clap(short, long, default_value_t = 30)]
     pub num_words: usize,
+    /// The file path to save results to
+    #[clap(short, long)]
+    pub results_file: Option<String>,
 }
 
 impl ToipeConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,11 @@ pub mod textgen;
 pub mod tui;
 pub mod wordlists;
 
-use std::io::StdinLock;
-use std::path::PathBuf;
-use std::time::Instant;
-
+use chrono::Local;
 use config::ToipeConfig;
 use results::ToipeResults;
+use std::io::StdinLock;
+use std::path::PathBuf;
 use termion::input::Keys;
 use termion::{color, event::Key, input::TermRead};
 use textgen::{RawWordSelector, WordSelector};
@@ -234,7 +233,7 @@ impl<'a> Toipe {
         // read first key
         let key = keys.next().unwrap()?;
         // start the timer
-        let started_at = Instant::now();
+        let started_at = Local::now();
         // process first key
         let mut status = process_key(key)?;
 
@@ -248,7 +247,7 @@ impl<'a> Toipe {
         }
 
         // stop the timer
-        let ended_at = Instant::now();
+        let ended_at = Local::now();
 
         let (final_chars_typed_correctly, final_uncorrected_errors) =
             input.iter().zip(original_text.iter()).fold(
@@ -293,7 +292,7 @@ impl<'a> Toipe {
         self.tui.display_lines::<&[Text], _>(&[
             &[Text::from(format!(
                 "Took {}s for {} words of {}",
-                results.duration().as_secs(),
+                results.duration_seconds(),
                 results.total_words,
                 self.config.text_name(),
             ))],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use config::ToipeConfig;
 use csv::WriterBuilder;
 use results::ToipeResults;
 use std::fs::{File, OpenOptions};
-use std::io::{self, StdinLock};
+use std::io::StdinLock;
 use std::path::{Path, PathBuf};
 use termion::input::Keys;
 use termion::{color, event::Key, input::TermRead};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@ use chrono::Local;
 use config::ToipeConfig;
 use csv::WriterBuilder;
 use results::ToipeResults;
-use std::fs::OpenOptions;
-use std::io::StdinLock;
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::{self, StdinLock};
+use std::path::{Path, PathBuf};
 use termion::input::Keys;
 use termion::{color, event::Key, input::TermRead};
 use textgen::{RawWordSelector, WordSelector};
@@ -301,11 +301,25 @@ impl<'a> Toipe {
 
     fn save_results(&self, results: ToipeResults) -> Result<(), std::io::Error> {
         if let Some(results_file) = &self.config.results_file {
-            let file = OpenOptions::new()
-                .append(true)
-                .create(true)
-                .open(results_file)?;
-            let mut writer = WriterBuilder::new().has_headers(false).from_writer(file);
+            fn get_file(results_file: &String) -> Result<File, std::io::Error> {
+                OpenOptions::new()
+                    .append(true)
+                    .create(true)
+                    .open(results_file)
+            }
+
+            let mut writer = if Path::new(results_file).exists() {
+                // Do not add headers, only want them at the top of the file
+                WriterBuilder::default()
+                    .has_headers(false)
+                    .from_writer(get_file(results_file)?)
+            } else {
+                // Add headers, this is the first write
+                WriterBuilder::new()
+                    .has_headers(true)
+                    .from_writer(get_file(results_file)?)
+            };
+
             writer.serialize(results)?;
         }
         Ok(())

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, Local};
 
 /// Stores stats from a typing test.
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize)]
 pub struct ToipeResults {
     /// number of words in given text
     pub total_words: usize,

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use chrono::{DateTime, Duration, Local};
 
 /// Stores stats from a typing test.
 #[derive(Clone)]
@@ -17,8 +17,8 @@ pub struct ToipeResults {
     pub final_chars_typed_correctly: usize,
     /// number of chars in given text that were wrongly typed at the end of the test
     pub final_uncorrected_errors: usize,
-    pub started_at: Instant,
-    pub ended_at: Instant,
+    pub started_at: DateTime<Local>,
+    pub ended_at: DateTime<Local>,
 }
 
 impl ToipeResults {
@@ -27,7 +27,14 @@ impl ToipeResults {
     /// i.e., the time between the user pressing the first key and them
     /// typing the last letter.
     pub fn duration(&self) -> Duration {
-        self.ended_at.duration_since(self.started_at)
+        self.ended_at - self.started_at
+    }
+
+    /// Convenience wrapper around ToipeResults.duration
+    ///
+    /// Gets seconds with sub second millis
+    pub fn duration_seconds(&self) -> f64 {
+        self.duration().num_milliseconds() as f64 / 1000.0
     }
 
     /// Percentage of letters that were typed correctly.
@@ -48,6 +55,6 @@ impl ToipeResults {
     pub fn wpm(&self) -> f64 {
         (self.final_chars_typed_correctly as f64 / 5.0 - self.final_uncorrected_errors as f64)
             .max(0.0) as f64
-            / (self.duration().as_secs_f64() / 60.0)
+            / (self.duration_seconds() / 60.0)
     }
 }


### PR DESCRIPTION
This PR should closes issue #11.

### Summary
This PR adds the ability to save results to a file via the `-r` flag. In the current implementation results *not* saved by default, instead the user must pass either the new `-r` flag and a path or set the `TOIPE_RESULTS_FILE` environment variable to a file path.

### Notes
The only particular thing that we might want to modify is the error type being returned by the `save_results` function I've added. I do not use `ToipeError` and instead fall back on `std::io::Error` which gets unrolled up where it is then turned into `ToipeError`, but in doing the error information is dropped. See [here](https://github.com/treatybreaker/csv-results/blob/532565b332ded73ad8a08b6c6434e0b4f2fe3da2/src/lib.rs#L302) for the `save_results` function and [here](https://github.com/treatybreaker/csv-results/blob/532565b332ded73ad8a08b6c6434e0b4f2fe3da2/src/lib.rs#L287) for how I'm taking the error in and returning `ToipeError`.
<br></br>
Let me know what suggestions you have and I'll be happy to make any relevant modifications. I'm not the biggest Rust guy, so I may have missed more idiomatic patterns that would improve this PR.