### PR TITLE
build(ci): use rust-toolchain+rust-cache actions and run all even on err

### DIFF
--- a/.github/workflows/lints-and-checks.yml
+++ b/.github/workflows/lints-and-checks.yml
@@ -11,14 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: "clippy,rustfmt"
+    - uses: Swatinem/rust-cache@v2
     - name: Check
       run: cargo check --verbose
     - name: Run tests
       run: cargo test --verbose
+      if: success() || failure()
     - name: Format
       run: cargo fmt --check
+      if: success() || failure()
     - name: Run Clippy
       run: cargo clippy -- -D warnings
+      if: success() || failure()
     - name: Check word lists
       run: ./scripts/check_word_lists.sh
+      if: success() || failure()


### PR DESCRIPTION
A part of #64 

- Uses https://github.com/dtolnay/rust-toolchain for getting the latest stable rust toolchain
- Uses https://github.com/Swatinem/rust-cache for caching deps
- Run all steps of the action even if one fails. This ensures that all errors are seen at once.