### PR TITLE
feat: read words sequentially

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,10 @@ pub struct ToipeConfig {
     /// Number of words to show on each test.
     #[clap(short, long, default_value_t = 30)]
     pub num_words: usize,
+
+    /// Read full text sequentially
+    #[clap(short = 's', long = "sequential", conflicts_with = "wordlist")]
+    pub use_sequential_words: bool,
 }
 
 impl ToipeConfig {


### PR DESCRIPTION
Hi there,

I want to practice over existing (non-randomized) texts. I'm toying with this. Maybe eventually, we can do something like `cat sample.txt | toipe`. 

What do you think of this idea?

---

This change will read words in a text file in sequence. No piping support yet. (Apologies in advance for bad Rust. I'm new to it).

The `-s` (sequential) flag must be provided in combination with `-f`.

Limitations:
- `-n` must be provided for long texts (over default 30)
- files with too many lines will not fit the screen
- there's no scrolling yet
- word/character filtering may need to be tweaked